### PR TITLE
Populate leaderboard in HomeVC from http request

### DIFF
--- a/eight-week-challenge/eight-week-challenge/HomeViewController.m
+++ b/eight-week-challenge/eight-week-challenge/HomeViewController.m
@@ -8,6 +8,7 @@
 
 #import "HomeViewController.h"
 #import "LeaderboardCell.h"
+@import AFNetworking;
 
 @interface HomeViewController () <UICollectionViewDataSource, UICollectionViewDelegate>
   @property (weak, nonatomic) IBOutlet UICollectionView *collectionView;
@@ -20,15 +21,22 @@
   [super viewDidLoad];
   self.collectionView.delegate = self;
   self.collectionView.dataSource = self;
-  self.leaderBoardItems = @[
-    [LeaderboardItem itemFromDict: @{@"name": @"Ulya", @"currentScore": @50}],
-    [LeaderboardItem itemFromDict: @{@"name": @"Natasha", @"currentScore": @40}],
-    [LeaderboardItem itemFromDict: @{@"name": @"Olga", @"currentScore": @35}]
-  ];
-
   UINib *leaderboardCell = [UINib nibWithNibName:@"LeaderboardCell" bundle:nil];
   [self.collectionView registerNib:leaderboardCell
         forCellWithReuseIdentifier:@"LeaderboardCell"];
+
+  NSString *leaderboardUrlString = @"https://demo2029138.mockable.io/leaderboard";
+  AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
+  [manager GET:leaderboardUrlString
+    parameters:nil
+      progress:nil
+       success:^(NSURLSessionTask *task, id responseObject) {
+         NSArray *leaderboardEntries = responseObject[@"leaderboard"];
+         self.leaderBoardItems = [LeaderboardItem itemsFromDicts: leaderboardEntries];
+         [self.collectionView reloadData];
+       } failure:^(NSURLSessionTask *operation, NSError *error) {
+         NSLog(@"Error: %@", error);
+       }]; 
 }
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView

--- a/eight-week-challenge/eight-week-challenge/LeaderboardItem.h
+++ b/eight-week-challenge/eight-week-challenge/LeaderboardItem.h
@@ -13,4 +13,5 @@
 @property (strong, nonatomic) NSNumber *currentScore;
 
 + (instancetype) itemFromDict:(NSDictionary*)dict;
++ (NSArray *) itemsFromDicts:(NSArray*)dicts;
 @end

--- a/eight-week-challenge/eight-week-challenge/LeaderboardItem.m
+++ b/eight-week-challenge/eight-week-challenge/LeaderboardItem.m
@@ -16,5 +16,16 @@
   item.currentScore = dict[@"currentScore"];
   return item;
 }
+
+
++ (NSArray *) itemsFromDicts:(NSArray*)dicts {
+  NSMutableArray *items = [NSMutableArray array];
+
+  for (NSDictionary *dict in dicts) {
+    [items addObject: [LeaderboardItem itemFromDict:dict]];
+  }
+
+  return items;
+}
   
 @end


### PR DESCRIPTION
Leaderboard mock api url: https://demo2029138.mockable.io/leaderboard

config panel: https://www.mockable.io/a/#/space/demo2029138/rest/UNn3gAAAA


<img width="453" alt="screen shot 2017-05-16 at 10 52 52 am" src="https://cloud.githubusercontent.com/assets/4433943/26120541/f568fafe-3a25-11e7-9885-90efff6b6868.png">
